### PR TITLE
Fix various content-list related issues

### DIFF
--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -52,6 +52,9 @@ a {
 }
 
 /* Customized Styles */
+ul.content-list {
+  padding-left: 0;
+}
 
 ul.content-list li {
   margin-bottom: 10px;
@@ -100,13 +103,19 @@ div.entry-content {
   text-align: justify;
 }
 
+article.list_item {
+  width: 100%;
+  overflow: hidden;
+}
+
 article.list_item div {
   display: inline-block;
-  max-width: 450px;
+  max-width: 490px;
 }
 
 article.list_item .thumb {
-  vertical-align: top;
+  max-width: 210px;
+  float: left;
 }
 
 .index-content article {
@@ -348,4 +357,3 @@ input.gsc-input,
 .event__description {
   margin-bottom: 20px;
 }
-


### PR DESCRIPTION
This contains fixes for the following two issues related to video listings:

First, videos with long titles broke the item rendering:

<img width="707" alt="content-width" src="https://cloud.githubusercontent.com/assets/3782/20073308/ffe2ffd2-a52b-11e6-98b7-2d07152a1139.png">

And second, there was a padding on the content-list itself that made little sense as it wasn't there on any other page. This fix removes that:

<img width="361" alt="list-gap" src="https://cloud.githubusercontent.com/assets/3782/20073318/06a5b9a4-a52c-11e6-89af-d397773f1912.png">
