### PR TITLE
Fix rendering of lists on medium and small devices

### DIFF
--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -51,6 +51,14 @@ ul.content-list {
   padding-left: 0;
 }
 
+.content-list .col-md-4 {
+  height: 360px;
+}
+
+.content-list .col-sm-6 {
+  height: 390px;
+}
+
 ul.content-list li {
   margin-bottom: 10px;
 }

--- a/themes/pytube-201601/templates/helpers.html
+++ b/themes/pytube-201601/templates/helpers.html
@@ -38,10 +38,10 @@
 
 {% macro video_list(articles, show_speakers=True, show_events=True) %}
   <div class="content-list">
+    <div class="row">
     {% for article in articles %}
-    {% if loop.index0 % 4 == 0 %}<div class="row">{% endif %}
     {{ video(article, class="col-lg-3 col-md-4 col-sm-6", show_speaker=show_speakers, show_event=show_events) }}
-    {% if loop.last or loop.index0 % 4 == 3 %}</div>{% endif %}
     {% endfor %}
+    </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
For now this requires that each video cell has a certain height
(targeted at 3-4 lines for the title).