### PR TITLE
Use HTTPS site URL config

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'http://pyvideo.org'
+SITEURL = 'https://pyvideo.org'
 RELATIVE_URLS = False
 
 DELETE_OUTPUT_DIRECTORY = True


### PR DESCRIPTION
Favicon is using non-HTTPS URL (http://pyvideo.org/theme/images/favicon.png)
Noticed after merging https://github.com/pyvideo/data/pull/606