### PR TITLE
Correct aggregation counts for talks with multiple speakers

### DIFF
--- a/plugins/aggregations.py
+++ b/plugins/aggregations.py
@@ -14,7 +14,7 @@ _speakers = defaultdict(dict)
 _tags = defaultdict(dict)
 
 CATEGORY_BLACKLIST = {'Undefined'}
-SPEAKER_BLACKLIST = {'Unknown'}
+SPEAKER_BLACKLIST = {'Unknown', 'Various speakers'}
 TAGS_BLACKLIST = {'pycon'}
 
 
@@ -31,13 +31,13 @@ def _handle_content_object_init(obj):
                 _categories[category.slug]['latest'] = latest
                 _categories[category.slug]['name'] = category.name
 
-        speaker = getattr(obj, 'author')
-        if speaker.name not in SPEAKER_BLACKLIST:
-            count = _speakers[speaker.slug].get('count', 0)
-            _speakers[speaker.slug]['name'] = speaker.name
-            _speakers[speaker.slug]['slug'] = speaker.slug
-            _speakers[speaker.slug]['url'] = speaker.url
-            _speakers[speaker.slug]['count'] = count + 1
+        for speaker in getattr(obj, 'authors'):
+            if speaker.name not in SPEAKER_BLACKLIST:
+                count = _speakers[speaker.slug].get('count', 0)
+                _speakers[speaker.slug]['name'] = speaker.name
+                _speakers[speaker.slug]['slug'] = speaker.slug
+                _speakers[speaker.slug]['url'] = speaker.url
+                _speakers[speaker.slug]['count'] = count + 1
 
         tags = getattr(obj, 'tags', ())
         if tags:


### PR DESCRIPTION
When a talk has multiple speakers, only the first author is credited in speaker counts on the homepage. 

For example, I'm shown as having 61 talks on [the speakers page](https://pyvideo.org/speakers.html), but only 46 on the homepage summary.

This is caused by an eccentricity of the Pelican data model. Pelican has two attributes for tracking authors - `author` and `authors`. `authors` always returns a list; if there are multiple authors, `author` only returns the first speaker. 

This PR modifies the collection of speaker count data to iterate over the full list of speakers, not just the first author. It also removes "Various speakers" from the aggregation list; while "Various Speakers" is a necessary placeholder when a talk has no available metadata, it's not especially useful as an aggregation.