### PR TITLE
List videos by language

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -6,6 +6,9 @@ import os
 
 AUTHOR = 'Unknown'
 SITENAME = 'PyVideo.org'
+TEMPLATE_PAGES = {
+    'languages.html': 'languages.html',
+}
 
 PATH = 'content'
 DATA_DIR = 'conferences'

--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -67,6 +67,14 @@ ul.content-list {
   height: 390px;
 }
 
+.language .content-list .col-md-4 {
+  height: 160px;
+}
+
+.language .content-list .col-sm-6 {
+  height: 160px;
+}
+
 ul.content-list li {
   margin-bottom: 10px;
 }
@@ -376,4 +384,8 @@ input.gsc-input,
 
 .event__description {
   margin-bottom: 20px;
+}
+
+.language {
+  display: none;
 }

--- a/themes/pytube-201601/static/js/language.js
+++ b/themes/pytube-201601/static/js/language.js
@@ -1,0 +1,9 @@
+$(window).bind( 'hashchange', function(){
+  "use strict";
+  var hash = location.hash;
+  $('.language').hide();
+  if (hash != "") {
+    $(hash).show();
+  }
+});
+$(window).trigger( 'hashchange' );

--- a/themes/pytube-201601/templates/base.html
+++ b/themes/pytube-201601/templates/base.html
@@ -132,6 +132,7 @@
       <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
       <script src="/theme/js/ie10-viewport-bug-workaround.js"></script>
       <script src="/theme/js/thumb.js"></script>
+      <script src="/theme/js/language.js"></script>
       {% include 'analytics.html' %}
       {% block extrajs %}{% endblock extrajs %}
     {% endblock endbodyjs %}

--- a/themes/pytube-201601/templates/helpers.html
+++ b/themes/pytube-201601/templates/helpers.html
@@ -1,8 +1,10 @@
-{% macro video(article, class="", show_speaker=True, show_event=True) -%}
+{% macro video(article, class="", show_speaker=True, show_event=True, show_thumbnail=True) -%}
   <article class="{{ class }}">
-    <a href="{{ SITEURL }}/{{ article.url }}">
-      <img src="{{ article.thumbnail_url }}" alt="Image from {{ article.title|striptags }}" />
-    </a>
+    {% if show_thumbnail %}
+        <a href="{{ SITEURL }}/{{ article.url }}">
+          <img src="{{ article.thumbnail_url }}" alt="Image from {{ article.title|striptags }}" />
+        </a>
+    {% endif %}
 
     <section class="details">
       <h4 class="entry-title">
@@ -36,11 +38,11 @@
   </article>
 {%- endmacro %}
 
-{% macro video_list(articles, show_speakers=True, show_events=True) %}
+{% macro video_list(articles, show_speakers=True, show_events=True, show_thumbnails=True) %}
   <div class="content-list">
     <div class="row">
     {% for article in articles %}
-    {{ video(article, class="col-lg-3 col-md-4 col-sm-6", show_speaker=show_speakers, show_event=show_events) }}
+    {{ video(article, class="col-lg-3 col-md-4 col-sm-6", show_speaker=show_speakers, show_event=show_events, show_thumbnail=show_thumbnails) }}
     {% endfor %}
     </div>
   </div>

--- a/themes/pytube-201601/templates/index.html
+++ b/themes/pytube-201601/templates/index.html
@@ -47,6 +47,15 @@
             </ul>
             <p><a href="{{ SITE_URL }}/tags.html">See all tags...</a></p>
         </section>
+        <section>
+            <h3>Most popular languages</h3>
+            <ul>
+            {% for count, name, lang in active_languages[:10] %}
+                <li><a href="{{ SITEURL }}/languages.html#{{ lang }}">{{ name }}</a> <span class="badge">{{ count }}</span></li>
+            {% endfor %}
+            </ul>
+            <p><a href="{{ SITE_URL }}/languages.html">See all languages...</a></p>
+        </section>
       </aside></div>
     </div>
   </div>

--- a/themes/pytube-201601/templates/languages.html
+++ b/themes/pytube-201601/templates/languages.html
@@ -1,0 +1,33 @@
+{% extends "list_filterable.html" %}
+{% from "helpers.html" import video_list %}
+
+{% block subtitle %} &middot; Languages{% endblock %}
+
+{% block content %}
+
+<h2>All Languages</h2>
+
+<div class="row">
+    <ul id="element-list">
+      {%- for name, lang, article_count, articles in languages %}
+        <li class="col-md-3 col-sm-4 col-xs-6">
+           <a href="#{{ lang }}">{{ name }}</a> <span class="badge">{{ article_count }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+</div>
+
+{%- for name, lang, article_count, articles in languages %}
+<div id="{{ lang }}" class="language">
+<h2>{{ name }}</h2>
+    <div class="row">
+      <div class="col-lg-12">
+        {{ video_list(articles, show_thumbnails=False) }}
+      </div>
+    </div>
+</div>
+{% endfor %}
+
+
+{% endblock %}
+


### PR DESCRIPTION
- Add page listing all the languages of the videos.
- Separate languages into tabs. Use JQuery to switch between the tabs.
- Show videos without the thumbnail as loading so many thumbnails on a singel page is not right.
- List most popular languages on the front page

Implementing #251 