### PR TITLE
Fix wrong youtube.com URL for youtu.be domain

### DIFF
--- a/plugins/json_reader.py
+++ b/plugins/json_reader.py
@@ -53,7 +53,7 @@ def _get_youtube_url(url):
     elif '/v/' in url:
         video_id = url_parsed.path.replace('/v/', '')
     elif 'youtu.be/' in url:
-        video_id = url_parsed.path
+        video_id = url_parsed.path.lstrip("/")
 
     return 'https://www.youtube.com/embed/{}'.format(video_id)
 


### PR DESCRIPTION
For videos, whose URL contains "youtu.be" domain, we're getting an extra
"/" between "www.youtube.com" and "video id" in actual video URL.

Resolves: #286