### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,7 +16,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - run: pip install -r requirements.in
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: pip install -r requirements.txt
       - run: make deploy-preview
       - uses: mshick/add-pr-comment@v1
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,5 +19,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - run: pip install -r requirements.in
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: pip install -r requirements.txt
       - run: make deploy


### PR DESCRIPTION
Use Python 3.9 in GitHub Actions to prevent failures due to newer
versions of Python and deprecations / removals in the standard library.