### PR TITLE
Upgrade pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.0.2  # via -r requirements.in
 pygments==2.1             # via pelican
 python-dateutil==2.4.2    # via pelican
-pytz==2015.7              # via feedgenerator, pelican
+pytz==2024.1              # via feedgenerator, pelican
 six==1.16.0               # via feedgenerator, pelican, python-dateutil
 unidecode==0.4.19         # via pelican


### PR DESCRIPTION
This change is a followup to #339 and upgrades `pytz` to its latest release. The upgrade produces no difference in the rendered site output as verified by [difftastic](https://difftastic.wilfred.me.uk/) with the command

```
difft main upgrade-pytz --skip-unchanged
```

on two full copies of the site created before and after installing the new requirements file.