### PR TITLE
Upgrade blinker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --annotation-style=line
 #
-blinker==1.4              # via pelican
+blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
 feedgenerator==1.7        # via pelican
 jinja2==2.10.1            # via -r requirements.in, pelican


### PR DESCRIPTION
This change is a followup to #341 and upgrades `blinker` to its latest release. The upgrade produces no difference in the rendered site output as verified by [difftastic](https://difftastic.wilfred.me.uk/) with the command

```
difft main upgrade-blinker --skip-unchanged
```

on two full copies of the site created before and after installing the new requirements file.