### PR TITLE
Upgrade markupsafe to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
 feedgenerator==1.7        # via pelican
 jinja2==2.10.1            # via -r requirements.in, pelican
-markupsafe==0.23          # via jinja2
+markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.0.2  # via -r requirements.in


### PR DESCRIPTION
This is an incremental upgrade of `markupsafe`. This change produces changes related to three videos, all of which are `alt` or `title` attributes that were previously generated incorrectly based on video titles and have been fixed by the change as noted in the ampersand-related [changelog entry](https://markupsafe.palletsprojects.com/en/latest/changes/#version-1-0) for `markupsafe` 1.0.