### PR TITLE
Upgrade jinja2 to 2.11.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 pelican==3.6.3
 pelican-alias==1.1
 pelican-extended-sitemap==1.0.2
-Jinja2==2.10.1
+Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
 feedgenerator==1.7        # via pelican
-jinja2==2.10.1            # via -r requirements.in, pelican
+jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in


### PR DESCRIPTION
This change is a followup to #344. This upgrade produces no difference in rendered site output from the commit before it. This is a stopgap upgrade before upgrading `jinja2` to the 3.x train, which will require upgrading `jinja2` and `markupsafe` together.