### PR TITLE
Upgrade pelican-extended-sitemap to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 pelican==3.6.3
 pelican-alias==1.1
-pelican-extended-sitemap==1.0.2
+pelican-extended-sitemap
 Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
-pelican-extended-sitemap==1.0.2  # via -r requirements.in
+pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.1             # via pelican
 python-dateutil==2.9.0.post0  # via pelican
 pytz==2024.1              # via feedgenerator, pelican


### PR DESCRIPTION
This upgrade includes a couple of bugfixes ([changelog]):

1. The sitemap now correctly uses the `modified` attributes from relevant pages.
2. The sitemap now includes entries for the speakers, tags, and events pages.

[changelog]: https://github.com/dArignac/pelican-extended-sitemap/blob/4076a1e19b1bd5a1f968c38e29df10dfe424736b/CHANGELOG.md