### PR TITLE
Add simple redirect plugin

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -98,6 +98,7 @@ PLUGINS = [
     'event_info',
     'aggregations',
     'writer',
+    'redirect',
 ]
 
 # https://en.wikipedia.org/wiki/ISO_639-3

--- a/plugins/redirect.py
+++ b/plugins/redirect.py
@@ -1,0 +1,72 @@
+import logging
+from pathlib import Path
+
+from jinja2 import BaseLoader, Environment
+from pelican import signals
+from pelican.generators import Generator
+
+logger = logging.getLogger(__name__)
+
+template = Environment(loader=BaseLoader()).from_string(
+    """
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset="utf-8" />
+            <meta http-equiv="refresh" content="0;url={{ destination }}" />
+        </head>
+    </html>
+    """
+)
+
+
+class RedirectGenerator(Generator):
+
+    def generate_output(self, writer):
+        redirects_file = (
+            Path(self.settings["PATH"]) / self.settings["DATA_DIR"] / "redirects.txt"
+        )
+        # If a redirects file doesn't exist, exit so that the site can be built without it
+        if not redirects_file.exists():
+            return
+
+        with open(redirects_file) as f:
+            redirects = f.readlines()
+
+        for line in redirects:
+            line = line.strip()
+            # Skip blank lines, treat lines beginning with `#` as comments
+            if not line or line.startswith("#"):
+                continue
+
+            # TODO: Currently, destination is intended to be used as a standard
+            # path. Future releases of Pelican support a semi-public API that
+            # helps with the URL lookup of tags by name, pages by file path, etc.
+            # This may be worth supporting in a future version of this plugin.
+            source, destination = line.split()
+
+            # Only support redirecting to on-site, root-level paths (for now)
+            if not destination.startswith("/"):
+                logger.warn(f"Not generating unsupported redirect to {destination}")
+                continue
+
+            source_path = Path(source)
+            if source_path.suffix:
+                source_file = source_path.name
+                source_path = source_path.parent
+            else:
+                source_file = "index.html"
+
+            output_directory = Path(self.output_path) / str(source_path).lstrip("/")
+            output_directory.mkdir(parents=True, exist_ok=True)
+            with open(output_directory / source_file, "w") as f:
+                f.write(template.render({"destination": destination}))
+
+
+def get_generators(generators):
+    return RedirectGenerator
+
+
+def register():
+    signals.get_generators.connect(get_generators)
+


### PR DESCRIPTION
Add a redirect plugin to generate redirect pages based on a "redirects.txt" file in the style of [Netlify] and [Cloudflare Pages] redirects. This is motivated by a couple of needs:

1. Redirects / aliases for old event pages have been broken for some time (https://github.com/pyvideo/pyvideo/issues/61, https://github.com/pyvideo/pyvideo/issues/244, and others not documented in the issue tracker) despite having aliases defined in the data repository. The pelican-alias plugin appears to work for pages and articles (videos, in the case of PyVideo) but not categories (used here for events). (The pelican-alias plugin could be updated to support this use case, but it has not been updated in some time.)

2. Redirecting URLs to rendered pages that are not file-backed is useful, for example in the context of renaming and combining tags, redirecting speaker pages to updated URLs, or any other pages that are generated via strings contained within other page files.

The goals of this initial version are to fix the broken links mentioned above and to unblock some efforts to clean up tags and improve speaker name support. This has been tested via generating redirect links for the currently-broken conference aliases, as shown in a followup commit in the pull request associated with this change.

[Netlify]: https://docs.netlify.com/routing/redirects/
[Cloudflare Pages]: https://developers.cloudflare.com/pages/configuration/redirects/