### PR TITLE
Upgrade feedgenerator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
-feedgenerator==1.7        # via pelican
+feedgenerator==1.8        # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
-feedgenerator==1.8        # via pelican
+feedgenerator==1.9        # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 blinker==1.8.2            # via pelican
 docutils==0.12            # via pelican
-feedgenerator==1.9        # via pelican
+feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
 pelican==3.6.3            # via -r requirements.in, pelican-alias


### PR DESCRIPTION
### 1.8

This upgrade produces different output for most (all?) feeds generated for PyVideo. The changes made in this version are primarily related to correcting the use of the `updated` vs. `published` elements, the use of the `isPermalink` attribute, and the removal of Atom-specific elements from RSS feeds.

These changes are noted in the [changelog], and the full list of changes can be found in the [commit diff].

---

### 1.9

Per the [changelog entry for 1.9](https://github.com/getpelican/feedgenerator/blob/c1e47f427d95ec71d5cfe651b268b063e5788741/CHANGELOG.md#190---2016-09-12) this change ensures that all Atom entries include `updated` elements.

---

### 1.9.2

Per the [changelog entry for 1.9.2](https://github.com/getpelican/feedgenerator/blob/c1e47f427d95ec71d5cfe651b268b063e5788741/CHANGELOG.md#192---2021-08-18), this change includes subtitles for Atom feeds (which appear to be unused by PyVideo).

1.9.1 included no functional changes.

---

This set of changes unblocks an upgrade for the version of Pelican used here.

[changelog]: https://github.com/getpelican/feedgenerator/blob/c1e47f427d95ec71d5cfe651b268b063e5788741/CHANGELOG.md#180---2016-04-05
[commit diff]: https://github.com/getpelican/feedgenerator/compare/232fb7aafcde2c957f42d1d0adb0cbda13aeb495...b836c975f674f4c23dce2ef8600005e99de53ead