### PR TITLE
Update readme to specify Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ First, pull down this repo's code::
 
 Then, install the dependencies for building this site. It is recommended to
 install all the requirements inside virtualenv_, use virtualenvwrapper_ to
-manage virtualenvs. **Building pyvideo.org requires Python 3.5**
+manage virtualenvs. **Building pyvideo.org requires Python 3.9**
 
 .. _virtualenv: https://virtualenv.pypa.io/en/latest/
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.org/en/latest/
@@ -46,7 +46,7 @@ manage virtualenvs. **Building pyvideo.org requires Python 3.5**
 First of all, create a virtual environment to install all the dependencies
 into either using virtualenvwrapper::
 
-  $ mkvirtualenv -p python3 pyvideo
+  $ mkvirtualenv -p python3.9 pyvideo
 
 \... or using pyvenv::
 


### PR DESCRIPTION
The readme currently and incorrectly specifies that building PyVideo requires 3.5. This change updates the version to 3.9 as is used by CI and in the GitHub Pages deployments.

Further development environment and documentation updates to follow.