### PR TITLE
Hotfix for build errors with uncommitted data directory changes

### DIFF
--- a/plugins/writer.py
+++ b/plugins/writer.py
@@ -40,8 +40,11 @@ class PyVideoWriter(Writer):
                 command.append(path)
                 output = subprocess.check_output(
                     command, universal_newlines=True)
-                dt = datetime.datetime.strptime(
-                    output.strip(), "%Y-%m-%d %H:%M:%S %z")
+                if output:
+                    dt = datetime.datetime.strptime(
+                        output.strip(), "%Y-%m-%d %H:%M:%S %z")
+                else:
+                    dt = datetime.datetime.now(tz=datetime.timezone.utc)
                 events.append((dt, directory))
             os.chdir(old_wd)
             events.sort(key=operator.itemgetter(1))


### PR DESCRIPTION
In some cases where there are new / uncommitted changes to the data directory, `make html` can fail. This is a result of attempting but failing to read the git commit date. This change falls back to the current time in failure cases to allow a build to complete.