### PR TITLE
Upgrade pelican: 3.6.3 -> 3.7.1

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -6,6 +6,7 @@ import os
 
 AUTHOR = 'Unknown'
 SITENAME = 'PyVideo.org'
+SITEURL = 'https://pyvideo.org'
 TEMPLATE_PAGES = {
     'languages.html': 'languages.html',
 }
@@ -62,6 +63,11 @@ AUTHOR_FEED_ATOM = 'feeds/speaker_%s.atom.xml'
 AUTHOR_FEED_RSS = 'feeds/speaker_%s.rss.xml'
 TAG_FEED_ATOM = 'feeds/tag_%s.atom.xml'
 TAG_FEED_RSS = 'feeds/tag_%s.rss.xml'
+
+# Preserve RSS summary behavior prior to 3.7.0
+# This setting may be temporary and exists to minimize the diffs
+# created when upgrading dependencies.
+RSS_FEED_SUMMARY_ONLY = False
 
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-pelican==3.6.3
+pelican==3.7.1
 pelican-alias==1.1
 pelican-extended-sitemap
 Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.12            # via pelican
 feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
-pelican==3.6.3            # via -r requirements.in, pelican-alias
+pelican==3.7.1            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.1             # via pelican


### PR DESCRIPTION
This change upgrades pelican's minor version with the goal of minimizing the diff of the build process output before and after the upgrade. Notes on the build output differences and updated settings are included below. The goal with this incremental change is to reduce the diff and review required to upgrade to the 4.x series.

New pelicanconf.py settings:

- SITEURL: this value is used by the RSS and Atom feed generators. It was previously unset, which introduces a source of diff between current and newly-generated feeds. This change is included as a result of some upgrade testing, however it the pelican docs recommend that this value be set in general, and so the updates here are more a case of "this change is an improvement that happens to help the upgrade process" than a direct upgrade requirement. A diff is produced in the locations that rely on pelican's feedgenerator dependency with or without this setting, so providing the SITEURL value makes that diff productive and independent of the pelican version.

- RSS_FEED_SUMMARY_ONLY: [this setting](https://docs.getpelican.com/en/3.7.0/settings.html#:~:text=RSS_FEED_SUMMARY_ONLY) was newly introduced in pelican 3.7.0 to preserve the old behavior of including all content in an RSS entry rather than only a summary. When set to False, this setting reduces the diff between output generated by pelican 3.6.3 and 3.7.x. (This previous behavior is noted in the [changelog](https://docs.getpelican.com/en/3.7.1/changelog.html).)

Output diff:

- Atom feeds include some new elements as documented in the [changelog](https://docs.getpelican.com/en/3.7.1/changelog.html).

- Atom and RSS feeds reference the SITEURL setting as noted above.

- Feed titles are now (as of 3.7.0) disambiguated to include "categories" (event, tag, or speaker names) as opposed to the old behavior of using only the SITENAME value.

- Some URL paths used in RSS and Atom feeds are now absolute instead of relative. The relative URLs were relative to the site root, so the diff is limited to a leading `/` character.

- Most differences included in this upgrade are limited to RSS and Atom feeds. Generated HTML files also include updates to feed and favicon URLs that make use of the newly-set SITEURL value but do not appear to contain any other content changes.