### PR TITLE
Upgrade Pelican from 3.7.1 to 4.0.1

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -57,12 +57,12 @@ USE_FOLDER_AS_CATEGORY = False
 FEED_MAX_ITEMS = 100
 FEED_ALL_ATOM = 'feeds/all.atom.xml'
 FEED_ALL_RSS = 'feeds/all.rss.xml'
-CATEGORY_FEED_ATOM = 'feeds/event_%s.atom.xml'
-CATEGORY_FEED_RSS = 'feeds/event_%s.rss.xml'
-AUTHOR_FEED_ATOM = 'feeds/speaker_%s.atom.xml'
-AUTHOR_FEED_RSS = 'feeds/speaker_%s.rss.xml'
-TAG_FEED_ATOM = 'feeds/tag_%s.atom.xml'
-TAG_FEED_RSS = 'feeds/tag_%s.rss.xml'
+CATEGORY_FEED_ATOM = 'feeds/event_{slug}.atom.xml'
+CATEGORY_FEED_RSS = 'feeds/event_{slug}.rss.xml'
+AUTHOR_FEED_ATOM = 'feeds/speaker_{slug}.atom.xml'
+AUTHOR_FEED_RSS = 'feeds/speaker_{slug}.rss.xml'
+TAG_FEED_ATOM = 'feeds/tag_{slug}.atom.xml'
+TAG_FEED_RSS = 'feeds/tag_{slug}.rss.xml'
 
 # Preserve RSS summary behavior prior to 3.7.0
 # This setting may be temporary and exists to minimize the diffs

--- a/plugins/drop_no_publish.py
+++ b/plugins/drop_no_publish.py
@@ -5,10 +5,12 @@ import os
 
 import pelican
 from pelican import signals
+import six
 
 
-# Monkey patch the ArticleGenerator to override specific method.
-# We have to override the `_include_path` method because it does not
+# Monkey patch the ArticleGenerator to override two specific methods.
+# 
+# 1. We have to override the `_include_path` method because it does not
 # filter files with enough specificity. If we wanted to filter a talk
 # at `categories/jacksconf/videos/jacks-talk.json`, we could do so
 # (without using this patch) by including `jacks-talk.json` in the
@@ -20,6 +22,17 @@ from pelican import signals
 # level.
 # Hopefully this patch can be removed by the merger of this PR:
 # https://github.com/getpelican/pelican/pull/1975
+#
+# 2. Override the `get_files` method to use the pre-4.0.0 behavior. This is
+# required to maintain consistent rendering with the behavior of PyVideo when
+# built using Pelican 3.7.1. In Pelican >=4.0.0, the `files` variable in this
+# method is a set rather than a list, which manifests as PyVideo tags
+# seemingly changing their case and formatting between renders due to file
+# ordering and name collisions after the tag names are run through Pelican's
+# `slugify` process. As a next step to remove this method override, the data
+# repository should be updated to ensure consistency with tags (e.g. "Data
+# Science" vs. "data science" vs. "data-science"), and a check should be added
+# to prevent future tag duplication.
 class PyVideoArticlesGenerator(pelican.ArticlesGenerator):
     def _include_path(self, path, extensions=None):
         """Inclusion logic for .get_files(), returns True/False
@@ -43,6 +56,49 @@ class PyVideoArticlesGenerator(pelican.ArticlesGenerator):
         if extensions is False or basename.endswith(extensions):
             return True
         return False
+
+    def get_files(self, paths, exclude=[], extensions=None):
+        """Return a list of files to use, based on rules
+        :param paths: the list pf paths to search (relative to self.path)
+        :param exclude: the list of path to exclude
+        :param extensions: the list of allowed extensions (if False, all
+            extensions are allowed)
+        """
+        # backward compatibility for older generators
+        if isinstance(paths, six.string_types):
+            paths = [paths]
+        # group the exclude dir names by parent path, for use with os.walk()
+        exclusions_by_dirpath = {}
+        for e in exclude:
+            parent_path, subdir = os.path.split(os.path.join(self.path, e))
+            exclusions_by_dirpath.setdefault(parent_path, set()).add(subdir)
+
+        files = []
+        ignores = self.settings['IGNORE_FILES']
+        for path in paths:
+            # careful: os.path.join() will add a slash when path == ''.
+            root = os.path.join(self.path, path) if path else self.path
+            if os.path.isdir(root):
+                for dirpath, dirs, temp_files in os.walk(
+                        root, followlinks=True):
+                    drop = []
+                    excl = exclusions_by_dirpath.get(dirpath, ())
+                    for d in dirs:
+                        if (d in excl or
+                            any(fnmatch.fnmatch(d, ignore)
+                                for ignore in ignores)):
+                            drop.append(d)
+                    for d in drop:
+                        dirs.remove(d)
+                    reldir = os.path.relpath(dirpath, self.path)
+                    for f in temp_files:
+                        fp = os.path.join(reldir, f)
+                        if self._include_path(fp, extensions):
+                            files.append(fp)
+            elif os.path.exists(root) and self._include_path(path, extensions):
+                files.append(path)  # can't walk non-directories
+        return files
+
 pelican.ArticlesGenerator = PyVideoArticlesGenerator
 
 

--- a/plugins/event_info.py
+++ b/plugins/event_info.py
@@ -14,6 +14,7 @@ import logging
 from pelican.readers import PelicanHTMLTranslator
 from pelican import generators
 from pelican import signals
+from pelican.settings import DEFAULT_CONFIG
 from pelican.utils import slugify
 from pathlib import Path
 
@@ -65,7 +66,7 @@ def _load_events():
         with open(str(metafile), encoding='utf-8') as fp:
             data = json.load(fp)
             title = data['title']
-            slug = slugify(title)
+            slug = slugify(title, regex_subs=DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS'])
             if data.get('description'):
                 data['description'] = _generate_html(data['description'])
             if title in events:

--- a/plugins/json_reader.py
+++ b/plugins/json_reader.py
@@ -8,6 +8,7 @@ import docutils
 import docutils.io
 from docutils.core import publish_parts
 from pelican import signals
+from pelican.settings import DEFAULT_CONFIG
 from pelican.readers import BaseReader, PelicanHTMLTranslator
 from pelican.utils import slugify
 
@@ -199,7 +200,7 @@ class JSONReader(BaseReader):
         title = _get_and_check_none(json_data, 'title', 'Title')
         slug = _get_and_check_none(json_data, 'slug')
         if slug is None:
-            slug = slugify(title)
+            slug = slugify(title, regex_subs=DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS'])
 
         metadata = {
             'title': title,

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-pelican==3.7.1
+pelican==4.0.1
 pelican-alias==1.1
 pelican-extended-sitemap
 Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.12            # via pelican
 feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
-pelican==3.7.1            # via -r requirements.in, pelican-alias
+pelican==4.0.1            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.1             # via pelican

--- a/themes/pyvideo-201601/templates/base.html
+++ b/themes/pyvideo-201601/templates/base.html
@@ -24,22 +24,22 @@
     <link href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
     {% endif %}
     {% if CATEGORY_FEED_ATOM and category %}
-    <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Event Atom Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM.format(slug=category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Event Atom Feed" />
     {% endif %}
     {% if CATEGORY_FEED_RSS and category %}
-    <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Event RSS Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS.format(slug=category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Event RSS Feed" />
     {% endif %}
     {% if AUTHOR_FEED_ATOM and author %}
-    <link href="{{ FEED_DOMAIN }}/{{ AUTHOR_FEED_ATOM|format(author.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Speaker Atom Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ AUTHOR_FEED_ATOM.format(slug=author.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Speaker Atom Feed" />
     {% endif %}
     {% if AUTHOR_FEED_RSS and author %}
-    <link href="{{ FEED_DOMAIN }}/{{ AUTHOR_FEED_RSS|format(author.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Speaker RSS Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ AUTHOR_FEED_RSS.format(slug=author.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Speaker RSS Feed" />
     {% endif %}
     {% if TAG_FEED_ATOM and tag %}
-    <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tag Atom Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM.format(slug=tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tag Atom Feed" />
     {% endif %}
     {% if TAG_FEED_RSS and tag %}
-    <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tag RSS Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS.format(slug=tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tag RSS Feed" />
     {% endif %}
 
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"


### PR DESCRIPTION
Upgrade Pelican from the 3.x series to the 4.x series. This upgrade unblocks other dependency upgrades and a Python version upgrade. Changes include:

1. The Pelican dependency version

2. URL and slug handling logic as recommended by the [changelog]

3. Overriding the `PyVideoArticleGenerator.get_files` method to preserve Pelican's pre-4.0 behavior to resolve tag rendering differences between two PyVideo builds

The output of these two versions has been compared using [difftastic] and found to be syntactically identical, so there should be no end-user differences present here.

[changelog]: https://docs.getpelican.com/en/4.0.1/changelog.html#id1
[difftastic]: https://difftastic.wilfred.me.uk/