### PR TITLE
Upgrade Pelican from 4.1.3 to 4.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-pelican==4.1.3
+pelican==4.2.0
 pelican-alias==1.1
 pelican-extended-sitemap
 Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.12            # via pelican
 feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
-pelican==4.1.3            # via -r requirements.in, pelican-alias
+pelican==4.2.0            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.1             # via pelican


### PR DESCRIPTION
Per the [changelog], the only change that affects PyVideo is the new inclusion of "category" (in PyVideo's case: conference name, meetup name, etc.) in the Atom and RSS feeds.

[changelog]: https://docs.getpelican.com/en/4.2.0/changelog.html