### PR TITLE
Upgrade pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.1             # via pelican
 python-dateutil==2.9.0.post0  # via pelican
-pytz==2024.1              # via feedgenerator, pelican
+pytz==2025.2              # via feedgenerator, pelican
 six==1.16.0               # via feedgenerator, pelican, python-dateutil
 unidecode==0.4.19         # via pelican


### PR DESCRIPTION
This upgrade produces no build output differences compared to `main`.