### PR TITLE
Upgrade pygments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ markupsafe==1.1.1         # via jinja2
 pelican==4.2.0            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
-pygments==2.1             # via pelican
+pygments==2.19.2          # via pelican
 python-dateutil==2.9.0.post0  # via pelican
 pytz==2025.2              # via feedgenerator, pelican
 six==1.16.0               # via feedgenerator, pelican, python-dateutil


### PR DESCRIPTION
This change upgrades pygments to the current release. This change includes minor build output changes to CSS class names used for styling. See the [pygments changelog](https://pygments.org/docs/changelog/) for full details.