### PR TITLE
Upgrade docutils

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -93,6 +93,13 @@ EXTRA_PATH_METADATA = {
     'extra/favicon.ico': {'path': 'favicon.ico'}
 }
 
+DOCUTILS_SETTINGS = {
+    # Temporarily revert the auto_id_prefix behavior to the pre-0.18.0 behavior
+    # to reduce the diff in output between versions for easier version upgrades.
+    # This setting can be removed to re-enable the newer default behavior.
+    "auto_id_prefix": "id",
+}
+
 PLUGIN_PATHS = ['plugins']
 PLUGINS = [
     'pelican_alias',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --annotation-style=line --cert=None --client-cert=None --index-url=None --pip-args=None
 #
 blinker==1.8.2            # via pelican
-docutils==0.12            # via pelican
+docutils==0.22.2          # via pelican
 feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2


### PR DESCRIPTION
Summary of the changes in build output behavior for PyVideo:

- 0.12 -> 0.13.1: HTML classes generated by docutils have been slightly modified for styling purposes
- 0.13.1 -> 0.17.1: No changes to PyVideo generated output
- 0.17.1 -> 0.18.0: Additional HTML class changes, changes to id generation behavior (temporarily reverted to old behavior via pelicanconf.py)
- 0.18.0 -> 0.22.2: No changes to PyVideo generated output

See the [changelog](https://docutils.sourceforge.io/RELEASE-NOTES.html) for full details.