### PR TITLE
Upgrade unidecode: 0.4.19 -> 1.3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ pygments==2.19.2          # via pelican
 python-dateutil==2.9.0.post0  # via pelican
 pytz==2025.2              # via feedgenerator, pelican
 six==1.16.0               # via feedgenerator, pelican, python-dateutil
-unidecode==0.4.19         # via pelican
+unidecode==1.3.6          # via pelican


### PR DESCRIPTION
This change upgrades unidecode to the latest release possible without introducing changes to the build artifacts output by PyVideo's build process. Further work is needed to upgrade to the latest release (just a few releases beyond this one), but those will require some review and possible reconciliation.