### PR TITLE
Upgrade Pelican: 4.2.0 -> 4.6.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-pelican==4.2.0
+pelican
 pelican-alias==1.1
 pelican-extended-sitemap
 Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ docutils==0.22.2          # via pelican
 feedgenerator==1.9.2      # via pelican
 jinja2==2.11.3            # via -r requirements.in, pelican
 markupsafe==1.1.1         # via jinja2
-pelican==4.2.0            # via -r requirements.in, pelican-alias
+pelican==4.6.0            # via -r requirements.in, pelican-alias
 pelican-alias==1.1        # via -r requirements.in
 pelican-extended-sitemap==1.2.3  # via -r requirements.in
 pygments==2.19.2          # via pelican
 python-dateutil==2.9.0.post0  # via pelican
 pytz==2025.2              # via feedgenerator, pelican
-six==1.16.0               # via feedgenerator, pelican, python-dateutil
+six==1.16.0               # via feedgenerator, python-dateutil
 unidecode==1.3.6          # via pelican


### PR DESCRIPTION
This change introduces a small difference in the behavior of unidecode for a single talk at one event and appears to otherwise output build artifacts consistent with PyVideo's output on Pelican 4.2.0.